### PR TITLE
rm non-ascii README chars, fixes Python3 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ Graphical user interface to view and modify Slurm state.
 What Our Users Say
 ------------------
 
-    I’ll never have to leave a notebook again
-    that’s like the ultimate dream
+    I'll never have to leave a notebook again
+    that's like the ultimate dream


### PR DESCRIPTION
Non-ASCII characters in README.md break installation for Python 3 :

```
[ryneches@dint18 slurm-magic (master) ]$ pip install .
Processing /global/u2/r/ryneches/pkg/slurm-magic
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/scratch/ryneches/pip-req-build-ryl0zy8d/setup.py", line 3, in <module>
        README = open('README.md').read()
      File "/global/homes/r/ryneches/opt/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3793: ordinal not in range(128)
```
Replacing them with their ASCII equivalents solves the problem.