### PR TITLE
Quick hack to make %srun non-blocking.

### DIFF
--- a/slurm_magic.py
+++ b/slurm_magic.py
@@ -160,13 +160,17 @@ class SlurmMagics(Magics):
         pass
 
     def _execute(self, line, input=None, stderr=False):
+        non_blocking = ["srun"]
+
         name = inspect.stack()[1][3]
         process = Popen([name] + line.split(), stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        stdout, stderr = process.communicate(input)
-        if stderr:
-            return stdout.decode("utf-8"), stderr.decode("utf-8")
-        else:
-            return stdout.decode("utf-8")
+
+        if name not in non_blocking:
+            stdout, stderr = process.communicate(input)
+            if stderr:
+                return stdout.decode("utf-8"), stderr.decode("utf-8")
+            else:
+                return stdout.decode("utf-8")
 
 
 def load_ipython_extension(ip):


### PR DESCRIPTION
This commit is related to #7. Although it is possible to send scripts in the background with the `%%script` magic, it seems useful to have access to `squeue` and other commands within the notebook with a visual response. 